### PR TITLE
fix(build-docker-image): 'No names found, cannot describe anything.' when retrieving version from git

### DIFF
--- a/build-docker-image/action.yaml
+++ b/build-docker-image/action.yaml
@@ -66,6 +66,7 @@ runs:
     - uses: actions/checkout@v2
 
       with:
+        fetch-depth: 0
         ref: ${{ inputs.checkout-ref }}
 
     - shell: bash


### PR DESCRIPTION
See https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything


Testing here: https://github.com/neohelden/actions-library/actions/runs/2058619022