### PR TITLE
fix(semantic-release): scheduled runs fail due to incorrect branch configuration

### DIFF
--- a/build-docker-image/action.yaml
+++ b/build-docker-image/action.yaml
@@ -99,13 +99,6 @@ runs:
     - name: set version of app
       shell: bash
       run: |
-
-        if [ -n "${{ github.event.repository.default_branch }}" ]; then
-          BRANCH_ADD=,"${{ github.event.repository.default_branch }}"
-        else 
-          BRANCH_ADD=
-        fi        
-
         if [ -f package.json ]; then
           npm version $(git describe --tags --abbrev=0) --git-tag-version=false
           COMMAND="npm version \${nextRelease.version} --git-tag-version=false"

--- a/build-docker-image/action.yaml
+++ b/build-docker-image/action.yaml
@@ -117,8 +117,15 @@ runs:
         fi
 
 
+        # for scheduled runs we do not have the default_branch in the event
+        if [ "${{ github.event.repository.default_branch }}"  == "" ] || [ "${{ github.event.repository.default_branch }}"  == "${GITHUB_REF#refs/*/}" ];then
+          DEFAULT_BRANCH=
+        else
+          DEFAULT_BRANCH=,"${{ github.event.repository.default_branch }}"
+        fi
+
         cat <<EOF > .releaserc.yaml
-        branches: ["${{ steps.extract_branch.outputs.short_ref }}"$BRANCH_ADD]
+        branches: ["${GITHUB_REF#refs/*/}${DEFAULT_BRANCH}"]
         tagFormat: '\${version}'
         dryRun: true
         ci: true

--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -127,8 +127,15 @@ runs:
     - name: Create PR for next release
       shell: bash
       run: |
+        # for scheduled runs we do not have the default_branch in the event
+        if [ "${{ github.event.repository.default_branch }}"  == "" ] || [ "${{ github.event.repository.default_branch }}"  == "${GITHUB_REF#refs/*/}" ];then
+          DEFAULT_BRANCH=
+        else
+          DEFAULT_BRANCH=,"${{ github.event.repository.default_branch }}"
+        fi
+
         cat <<EOF > .releaserc.yaml
-        branches: ["${GITHUB_REF#refs/*/}","${{ github.event.repository.default_branch }}"]
+        branches: ["${GITHUB_REF#refs/*/}${DEFAULT_BRANCH}"]
         tagFormat: '${{ inputs.release-prefix }}\${version}'
         dryRun: true
         ci: true


### PR DESCRIPTION
Tested here
* [Scheduled run Test](https://github.com/neohelden/actions-test-project/runs/5769191950?check_suite_focus=true)
* [Push to branch](https://github.com/neohelden/actions-test-project/runs/5769121654?check_suite_focus=true) (the error in the pipeline is due to directly pushing to brach `develop` in test project)