### PR TITLE
fix(build-jib-image): correctly state as string

### DIFF
--- a/build-jib-image/action.yaml
+++ b/build-jib-image/action.yaml
@@ -71,7 +71,7 @@ runs:
       id: image-tags
       shell: bash
       run: |
-        IN=${{ steps.docker_meta.outputs.tags }}
+        IN="${{ steps.docker_meta.outputs.tags }}"
         arrIN=(${IN//:/ })
         echo ::set-output name=tag-only::${arrIN[1]}
 


### PR DESCRIPTION
Fixes an error where multiple tags would fail the pipeline