### PR TITLE
fix(build-and-deploy-container-image): do not analyze PRs as branches

### DIFF
--- a/.github/workflows/build-and-deploy-container-image.yaml
+++ b/.github/workflows/build-and-deploy-container-image.yaml
@@ -112,7 +112,7 @@ on:
       sonar-branch-name:
         type: string
         description: Branch name to by analyzed. Must be empty for PR builds.
-        default: ${{ github.event.pull_request.head.ref || github.event.ref }}
+        default: ${{ github.event.ref }}
         required: false
       sonar-sources:
         type: string


### PR DESCRIPTION
This fixes an issue where sonarCloud would analyze PRs as branches and therfore would not pin a comment

---
https://github.com/neohelden/NEAP/runs/7688135410?check_suite_focus=true