### PR TITLE
fix(build-and-deploy-container-image): 'sonar.pullrequest.branch' is mandatory for a pull request analysis

### DIFF
--- a/.github/workflows/build-and-deploy-container-image.yaml
+++ b/.github/workflows/build-and-deploy-container-image.yaml
@@ -109,11 +109,6 @@ on:
         description: The project's unique key. Allowed characters are letters, numbers, -, _, . and :, with at least one non-digit.
         default: ${{ github.event.repository.name }}
         required: false
-      sonar-branch-name:
-        type: string
-        description: Branch name to by analyzed. Must be empty for PR builds.
-        default: ${{ github.event.ref }}
-        required: false
       sonar-sources:
         type: string
         description: Comma-separated paths to directories containing main source files.
@@ -401,7 +396,7 @@ jobs:
           sonar-project-base-dir: ${{ inputs.sonar-project-base-dir }}
           sonar-organization: ${{ inputs.sonar-organization }}
           sonar-projectKey: ${{ inputs.sonar-projectKey }}
-          sonar-branch-name: ${{ inputs.sonar-branch-name }}
+          sonar-branch-name: ${{ github.event.ref }}
           sonar-sources: ${{ inputs.sonar-sources }}
           sonar-inclusions: ${{ inputs.sonar-inclusions }}
           sonar-exclusions: ${{ inputs.sonar-exclusions }}
@@ -426,7 +421,7 @@ jobs:
           sonar-project-base-dir: ${{ inputs.sonar-project-base-dir }}
           sonar-organization: ${{ inputs.sonar-organization }}
           sonar-projectKey: ${{ inputs.sonar-projectKey }}
-          sonar-branch-name: ${{ inputs.sonar-branch-name }}
+          sonar-branch-name: ${{ github.event.pull_request.head.ref || github.event.ref }}
           default-branch: ${{ inputs.default-branch }}
 
   check-code-compliance:


### PR DESCRIPTION
Sonar branch name cannot be set from outside of workflow anymore. This way we can handle sonar configuration differently for yarn and gradle. 
So far no project overrides the sonar branch name so this should be fine.

* https://github.com/neohelden/neap-portal-service/pull/35