### PR TITLE
fix(build-docker-image): set branches when on master

### DIFF
--- a/.github/workflows/build-and-deploy-container-image.yaml
+++ b/.github/workflows/build-and-deploy-container-image.yaml
@@ -473,7 +473,7 @@ jobs:
           image-tag: ${{ inputs.image-tag }}
 
       - name: Build Docker image
-        uses: neohelden/actions-library/build-docker-image@default-branch
+        uses: neohelden/actions-library/build-docker-image@main
         if: needs.prepare.outputs.docker-file-exists == 'true'
         with:
           image-registry-username: ${{ secrets.image-registry-username }}

--- a/.github/workflows/build-and-deploy-container-image.yaml
+++ b/.github/workflows/build-and-deploy-container-image.yaml
@@ -473,7 +473,7 @@ jobs:
           image-tag: ${{ inputs.image-tag }}
 
       - name: Build Docker image
-        uses: neohelden/actions-library/build-docker-image@main
+        uses: neohelden/actions-library/build-docker-image@default-branch
         if: needs.prepare.outputs.docker-file-exists == 'true'
         with:
           image-registry-username: ${{ secrets.image-registry-username }}

--- a/build-docker-image/action.yaml
+++ b/build-docker-image/action.yaml
@@ -118,7 +118,7 @@ runs:
         fi
 
         cat <<EOF > .releaserc.yaml
-        branches: ["${GITHUB_REF#refs/*/}${DEFAULT_BRANCH}"]
+        branches: ["${GITHUB_REF#refs/*/}"${DEFAULT_BRANCH}]
         tagFormat: '\${version}'
         dryRun: true
         ci: true


### PR DESCRIPTION
This fixes an issue where a run on master will not produce a correct semrel config since default branch is develop

Main: https://github.com/neohelden/actions-test-project/actions/runs/3196951681/jobs/5219573744
Develop PR: https://github.com/neohelden/actions-test-project/actions/runs/3196918877/jobs/5219495192
Devrelop: https://github.com/neohelden/actions-test-project/actions/runs/3196918735/jobs/5219497810