### PR TITLE
fix(check-code-compliance): pin cyclonedx/bom to version 3

### DIFF
--- a/check-code-compliance/action.yaml
+++ b/check-code-compliance/action.yaml
@@ -186,7 +186,7 @@ runs:
     - name: Generate CycloneDX SBOM
       working-directory: ./
       if: steps.check_node.outputs.node-project == 'true'
-      run: npx @cyclonedx/bom -o bom.xml
+      run: npx @cyclonedx/bom@3 -o bom.xml
       shell: bash
 
     - name: Upload SBOM


### PR DESCRIPTION
This fixes an issue where the BOM could not be created due to a breaking change