### PR TITLE
fix: pin nodeJS version to 16.x

### DIFF
--- a/build-and-test-with-yarn/action.yaml
+++ b/build-and-test-with-yarn/action.yaml
@@ -91,7 +91,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: "16.x"
     - name: Branch name
       id: extract_branch
       run: |

--- a/build-and-test-with-yarn/action.yaml
+++ b/build-and-test-with-yarn/action.yaml
@@ -89,6 +89,9 @@ runs:
   using: "composite"
 
   steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
     - name: Branch name
       id: extract_branch
       run: |

--- a/check-code-compliance/action.yaml
+++ b/check-code-compliance/action.yaml
@@ -25,6 +25,9 @@ runs:
   using: "composite"
 
   steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
     - uses: actions/checkout@v2
       with:
         ref: ${{ inputs.checkout-ref }}

--- a/check-code-compliance/action.yaml
+++ b/check-code-compliance/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: "16.x"
     - uses: actions/checkout@v2
       with:
         ref: ${{ inputs.checkout-ref }}


### PR DESCRIPTION
This resolves an issue where code would not build since nodejs 16 Was the default version until Feb. 13 2023