### PR TITLE
fix(build-and-test-with-yarn): use static binary

### DIFF
--- a/.github/workflows/build-and-deploy-container-image.yaml
+++ b/.github/workflows/build-and-deploy-container-image.yaml
@@ -393,7 +393,7 @@ jobs:
           app_id: ${{ secrets.gh-app-id }}
           private_key: ${{ secrets.gh-app-private-key }}
 
-      - uses: neohelden/actions-library/build-and-test-with-yarn@opa-glibc
+      - uses: neohelden/actions-library/build-and-test-with-yarn@main
         if: needs.prepare.outputs.package-json-available == 'true'
         with:
           sonar-token: ${{ secrets.sonar-token }}

--- a/.github/workflows/build-and-deploy-container-image.yaml
+++ b/.github/workflows/build-and-deploy-container-image.yaml
@@ -393,7 +393,7 @@ jobs:
           app_id: ${{ secrets.gh-app-id }}
           private_key: ${{ secrets.gh-app-private-key }}
 
-      - uses: neohelden/actions-library/build-and-test-with-yarn@main
+      - uses: neohelden/actions-library/build-and-test-with-yarn@opa-glibc
         if: needs.prepare.outputs.package-json-available == 'true'
         with:
           sonar-token: ${{ secrets.sonar-token }}

--- a/build-and-test-with-yarn/action.yaml
+++ b/build-and-test-with-yarn/action.yaml
@@ -104,18 +104,12 @@ runs:
           echo "branch=" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
-    
-    - name: Install GLIBC
-      if: runner.os == 'Linux'
-      run: |
-        apt-get update
-        apt-get install -y --no-install-recommends libc6
-      shell: bash
 
     - name: Setup OPA
       uses: open-policy-agent/setup-opa@v2
       with:
         version: latest
+        static: "true"
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/build-and-test-with-yarn/action.yaml
+++ b/build-and-test-with-yarn/action.yaml
@@ -104,6 +104,13 @@ runs:
           echo "branch=" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
+    
+    - name: Install GLIBC
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libc6
+      shell: bash
 
     - name: Setup OPA
       uses: open-policy-agent/setup-opa@v2

--- a/build-and-test-with-yarn/action.yaml
+++ b/build-and-test-with-yarn/action.yaml
@@ -108,8 +108,8 @@ runs:
     - name: Install GLIBC
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libc6
+        apt-get update
+        apt-get install -y --no-install-recommends libc6
       shell: bash
 
     - name: Setup OPA


### PR DESCRIPTION
This fixes an issue where the downloaded OPA binary would not find the correct GLIBC version