### PR TITLE
fix(semantic-release): bump release packages

### DIFF
--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -78,10 +78,10 @@ runs:
       shell: bash
       run: |
         sudo npm install -g \
-          semantic-release@19 \
+          semantic-release@23 \
           @semantic-release/git@10 \
-          @semantic-release/release-notes-generator@10 \
-          @semantic-release/github@8 \
+          @semantic-release/release-notes-generator@13 \
+          @semantic-release/github@10 \
           @semantic-release/exec@6
 
     - name: Install ${{ inputs.extra-plugins }}


### PR DESCRIPTION
semantic-release from 19 to 23
@semantic-release/release-notes-generator from 10 to 13 
@semantic-release/github from 8 to 10