### PR TITLE
fix(semantic-release): use global semantic release installation instead of local one

### DIFF
--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -150,7 +150,7 @@ runs:
             ]
         EOF
 
-        npx semantic-release --debug
+        semantic-release --debug
 
         cat <<EOF > template.erb
         Release $(cat version.txt)


### PR DESCRIPTION


This fixes an issue where semantic release would be installed locally instead of globally