### PR TITLE
fix(semantic-release): calculate branches without quotes

### DIFF
--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -140,7 +140,7 @@ runs:
         fi
 
         cat <<EOF > .releaserc.yaml
-        branches: ["${GITHUB_REF#refs/*/}${DEFAULT_BRANCH}"]
+        branches: [${GITHUB_REF#refs/*/}${DEFAULT_BRANCH}]
         tagFormat: '${{ inputs.release-prefix }}\${version}'
         dryRun: true
         ci: true


### PR DESCRIPTION
This fixes an error when semantic release is not executed on the repository default branch