### PR TITLE
fix(semantic-release): use token to perform semantic-release actions

### DIFF
--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -105,6 +105,11 @@ runs:
         app_id: ${{ inputs.gh-app-id }}
         private_key: ${{ inputs.gh-app-private-key }}
 
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.checkout-ref }}
+        token: ${{ steps.generate_token.outputs.token }}
+
     - name: Create semantic release
       shell: bash
       run: |


### PR DESCRIPTION
This fixes an issue where the token used by semantic-release is allowed to write to a repository but actions are not (see https://github.com/orgs/community/discussions/25305)