### PR TITLE
fix(build-and-test-with-yarn): add eslint checks for v5

### DIFF
--- a/build-and-test-with-yarn/action.yaml
+++ b/build-and-test-with-yarn/action.yaml
@@ -167,7 +167,8 @@ runs:
       id: checkEsLint
       run: |
         FILE=${{ inputs.eslint-configuration-file }}
-        if [ -f "$FILE" ]
+        ESLINT_V5_FILE=eslint.config.mjs
+        if [ -f "$FILE" ] || [ -f "$ESLINT_V5_FILE" ]
         then
           echo "runEslint=true" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
This fixes an issue where ESLint v5 would not be run