### PR TITLE
fix(semantic-release): do not clean repository on token change

### DIFF
--- a/semantic-release/action.yaml
+++ b/semantic-release/action.yaml
@@ -108,6 +108,7 @@ runs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.checkout-ref }}
+        clean: false
         token: ${{ steps.generate_token.outputs.token }}
 
     - name: Create semantic release


### PR DESCRIPTION
This fixes an issue where a token change would clean the whole repository and therefore would not publish NPM packages